### PR TITLE
[RHPAM-1778] Change smartrouter protocol and use kieserver route as host

### DIFF
--- a/dev-overrides.yaml
+++ b/dev-overrides.yaml
@@ -1,4 +1,4 @@
 schema_version: 1
 
-name: "rhpam-7/rhpam71-apb-dev"
+name: "rhpam-7/rhpam72-apb-dev"
 from: "ansibleplaybookbundle/apb-base:v3.11"

--- a/dev-overrides.yaml
+++ b/dev-overrides.yaml
@@ -1,4 +1,4 @@
 schema_version: 1
 
-name: "rhpam-7/rhpam72-apb-dev"
+name: "rhpam-7/rhpam7-apb-dev"
 from: "ansibleplaybookbundle/apb-base:v3.11"

--- a/image.yaml
+++ b/image.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
-name: "rhpam-7/rhpam71-apb"
-description: "Red Hat Business Central 7.1 OpenShift Ansible Playbook Bundle"
+name: "rhpam-7/rhpam72-apb"
+description: "Red Hat Business Central 7.2 OpenShift Ansible Playbook Bundle"
 version: "1.0"
 from: "openshift3/apb-base:v3.11"
 labels:
@@ -10,7 +10,7 @@ labels:
   - name: "io.k8s.description"
     value: "Platform for running Red Hat Process Automation Manager"
   - name: "io.k8s.display-name"
-    value: "Red Hat Process Automation Manager 7.1"
+    value: "Red Hat Process Automation Manager 7.2"
   - name: "io.openshift.tags"
     value: "javaee,eap,eap7,rhpam,rhpam7,apb"
   - name: "com.redhat.apb.spec"
@@ -29,4 +29,4 @@ packages:
 osbs:
   repository:
     name: apbs/rhpam
-    branch: rhpam-7.1-rhel-7
+    branch: rhpam-7.2-rhel-7

--- a/image.yaml
+++ b/image.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 
-name: "rhpam-7/rhpam72-apb"
+name: "rhpam-7/rhpam7-apb"
 description: "Red Hat Business Central 7.2 OpenShift Ansible Playbook Bundle"
 version: "1.0"
 from: "openshift3/apb-base:v3.11"
@@ -28,5 +28,5 @@ packages:
     - java-1.8.0-openjdk-headless
 osbs:
   repository:
-    name: apbs/rhpam
-    branch: rhpam-7.2-rhel-7
+    name: apbs/rhpam-7-apb-openshift
+    branch: rhpam-7-rhel-7

--- a/modules/rhpam-apb/roles/deploy-kieserver/templates/kieserver-dc.yml.j2
+++ b/modules/rhpam-apb/roles/deploy-kieserver/templates/kieserver-dc.yml.j2
@@ -165,9 +165,7 @@ spec:
           - name: KIE_SERVER_ID
             value: '{{ kieserver_service_name }}'
           - name: KIE_SERVER_HOST
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
+            value: "{{ ks_host | default('') }}"
           - name: KIE_SERVER_PORT
             value: "8080"
           - name: KIE_SERVER_USER

--- a/modules/rhpam-apb/roles/deploy-smartrouter/templates/smartrouter-dc.yml.j2
+++ b/modules/rhpam-apb/roles/deploy-smartrouter/templates/smartrouter-dc.yml.j2
@@ -67,7 +67,7 @@ spec:
         - name: KIE_SERVER_CONTROLLER_SERVICE
           value: "{{ controller_svc }}"
         - name: KIE_SERVER_CONTROLLER_PROTOCOL
-          value: "ws"
+          value: "http"
         - name: KIE_SERVER_ROUTER_REPO
           value: "/opt/rhpam-smartrouter/data"
         - name: KIE_SERVER_ROUTER_CONFIG_WATCHER_ENABLED


### PR DESCRIPTION
Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

* Updated missing references to rhpam72
* SmartRouter: use `http` protocol instead of `ws`
* Kie Server: Use route as host name instead of PodIP. As they are registered using `ws` protocol the hostname is only meaningful in the UI link

Fix https://issues.jboss.org/browse/RHPAM-1778