### PR TITLE
[KIECLOUD-121][RHPAM-1909_master] align APB with upstream changes to KIE_SERVER_MODE

### DIFF
--- a/apb.yml
+++ b/apb.yml
@@ -159,11 +159,11 @@ _apb_businesscentral_maven_repo_pwd: &_apb_businesscentral_maven_repo_pwd
 _apb_kieserver_mode: &_apb_kieserver_mode
   name: apb_kieserver_mode
   title: Process Server Mode
-  description: The KIE Server mode. Valid values are 'development' or 'production'. (Sets the org.kie.server.mode system property).
+  description: The KIE Server mode. Valid values are 'DEVELOPMENT' or 'PRODUCTION'. (Sets the org.kie.server.mode system property).
   required: true
   type: enum
-  enum: ['development', 'production']
-  default: production
+  enum: ['DEVELOPMENT', 'PRODUCTION']
+  default: DEVELOPMENT
   display_group: Process Server
 _apb_kieserver_image_stream_name: &_apb_kieserver_image_stream_name
   name: apb_kieserver_image_stream_name

--- a/modules/rhpam-apb/roles/deploy-kieserver/defaults/main.yml
+++ b/modules/rhpam-apb/roles/deploy-kieserver/defaults/main.yml
@@ -37,7 +37,7 @@ controller_token: "{{ apb_controller_token | default('', true) | trim }}"
 
 kieserver_mgmt_disabled: false
 
-kieserver_mode: "{{ apb_kieserver_mode | default('production', true) }}"
+kieserver_mode: "{{ apb_kieserver_mode | default('DEVELOPMENT', true) }}"
 kieserver_db_type: "{{ apb_kieserver_db_type }}"
 kieserver_db_size: "{{ apb_kieserver_db_size | default('', true) | trim  }}"
 

--- a/modules/rhpam-apb/roles/rhpam-apb/tasks/main.yml
+++ b/modules/rhpam-apb/roles/rhpam-apb/tasks/main.yml
@@ -33,7 +33,7 @@
       include_role:
         name: deploy-kieserver
       vars:
-        kieserver_mode: 'development'
+        kieserver_mode: 'DEVELOPMENT'
         kieserver_db_type: 'H2'
         kieserver_replicas: 1
         kieserver_startup_strategy: "{{ apb_kieserver_startup_strategy | default('ControllerBasedStartupStrategy', true) | trim }}"


### PR DESCRIPTION
[KIECLOUD-121][RHPAM-1909_master] align APB with upstream changes to KIE_SERVER_MODE
https://issues.jboss.org/browse/KIECLOUD-121
https://issues.jboss.org/browse/RHPAM-1909

Signed-off-by: David Ward <dward@redhat.com>

Please see the latest comments on KIECLOUD-121. The default needs to be DEVELOPMENT in most cases (especially for authoring purposes).

Note: This PR does not include an update to image.yaml's "com.redhat.apb.spec", as I don't know how to calculate that value.