### PR TITLE
[RHPAM-1952] (7.3.1) Exception is thrown by Business central when user clicks on deployment unit

### DIFF
--- a/modules/rhpam-apb/roles/deploy-kieserver/templates/kieserver-dc.yml.j2
+++ b/modules/rhpam-apb/roles/deploy-kieserver/templates/kieserver-dc.yml.j2
@@ -11,6 +11,7 @@ spec:
   strategy:
     type: Rolling
     rollingParams:
+      maxSurge: 100%
       maxUnavailable: 0
   triggers:
     - type: ImageChange


### PR DESCRIPTION
Propagate changes from RHPAM template.

Related PRs.
https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/267
