### PR TITLE
[KIECLOUD-185] APB image doesn't contain OCP environment variable changes

### DIFF
--- a/modules/rhpam-apb/roles/deploy-businesscentral-monitoring/templates/businesscentral-monitoring-dc.yml.j2
+++ b/modules/rhpam-apb/roles/deploy-businesscentral-monitoring/templates/businesscentral-monitoring-dc.yml.j2
@@ -107,11 +107,11 @@ spec:
               value: '{{ businesscentral_keystore_pwd }}'
 {% if controller_ocp_enabled %}
 ## OpenShift Enhancement BEGIN
-            - name: KIE_CONTROLLER_OCP_ENABLED
+            - name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
               value: "{{ controller_ocp_enabled }}"
-            - name: KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
+            - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
               value: "{{ controller_prefer_kieserver_svc }}"
-            - name: KIE_CONTROLLER_TEMPLATE_CACHE_TTL
+            - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
               value: "{{ controller_template_cache_ttl }}"
 ## OpenShift Enhancement END
 {% endif %}

--- a/modules/rhpam-apb/roles/deploy-businesscentral/templates/businesscentral-dc.yml.j2
+++ b/modules/rhpam-apb/roles/deploy-businesscentral/templates/businesscentral-dc.yml.j2
@@ -91,11 +91,11 @@ spec:
               value: '{{ kie_execution_pwd }}'
 {% if controller_ocp_enabled %}
 ## OpenShift Enhancement BEGIN
-            - name: KIE_CONTROLLER_OCP_ENABLED
+            - name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
               value: "{{ controller_ocp_enabled }}"
-            - name: KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
+            - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
               value: "{{ controller_prefer_kieserver_svc }}"
-            - name: KIE_CONTROLLER_TEMPLATE_CACHE_TTL
+            - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
               value: "{{ controller_template_cache_ttl }}"
 ## OpenShift Enhancement END
 {% endif %}


### PR DESCRIPTION
Latest 7.3.x changes related to KIECLOUD-134 [1] ended with renamed environment variables related to OpenShiftStartupStrategy. However the environment variables weren't changed in APB [2] [3], making OpenShiftStartupStrategy there unusable.

Related PRs.
https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/246/files