### PR TITLE
Enable pulp_repos.

### DIFF
--- a/container.yaml
+++ b/container.yaml
@@ -2,3 +2,6 @@ image_build_method: imagebuilder
 platforms:
   only:
   - x86_64
+
+compose:
+  pulp_repos: true


### PR DESCRIPTION
Activate pulp_repos option to avoid the usage of unsigned repositories that may lead to include unsigned RPMs into images. With pulp_repos option enabled it should use pulp repositories (http://pulp.dist.prod.ext.phx2.redhat.com/...) that don't include unsigned RPMs.