### PR TITLE
[KIECLOUD-160] Removing git port from container and add ROUTE_NAME

### DIFF
--- a/modules/rhpam-apb/roles/deploy-businesscentral/tasks/services.yml
+++ b/modules/rhpam-apb/roles/deploy-businesscentral/tasks/services.yml
@@ -24,6 +24,3 @@
           - name: https
             port: 8443
             targetPort: 8443
-          - name: git-ssh
-            port: 8001
-            targetPort: 8001

--- a/modules/rhpam-apb/roles/deploy-businesscentral/templates/businesscentral-dc.yml.j2
+++ b/modules/rhpam-apb/roles/deploy-businesscentral/templates/businesscentral-dc.yml.j2
@@ -69,9 +69,6 @@ spec:
             - name: https
               containerPort: 8443
               protocol: TCP
-            - name: git-ssh
-              containerPort: 8001
-              protocol: TCP
           env:
             - name: KIE_ADMIN_USER
               value: '{{ kie_admin_user }}'
@@ -87,6 +84,8 @@ spec:
               value: '{{ kie_execution_user }}'
             - name: KIE_SERVER_PWD
               value: '{{ kie_execution_pwd }}'
+            - name:  WORKBENCH_ROUTE_NAME
+              value: '{{ businesscentral_deployment_name }}' 
 ## OpenShift Enhancement BEGIN
             - name: KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
               value: "{{ controller_global_discovery }}"


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KIECLOUD-160

Removing unnecessary git ports and introducing the `WORKBENCH_ROUTE_NAME` needed for our inner script to set correctly the HTTP git url.

Signed-off-by: Ricardo Zanini <zanini@redhat.com>